### PR TITLE
CI/Maven Maintenance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,13 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
+          cache: 'maven'
       - name: Build with Maven
         run: mvn --batch-mode --update-snapshots package
   publish:
     runs-on: ubuntu-latest
+    needs: build
+    if: github.repository == 'tomnelson/jungrapht-visualization'
     steps:
       - uses: actions/checkout@v3
       - name: Set up Maven Snapshot Repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -25,9 +25,9 @@ jobs:
     needs: build
     if: github.repository == 'tomnelson/jungrapht-visualization'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Maven Snapshot Repository
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/jungrapht-layout/pom.xml
+++ b/jungrapht-layout/pom.xml
@@ -37,4 +37,11 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/jungrapht-visualization/pom.xml
+++ b/jungrapht-visualization/pom.xml
@@ -42,4 +42,11 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -30,9 +30,6 @@
             <timezone>-5</timezone>
         </developer>
     </developers>
-    <prerequisites>
-        <maven>3.1.1</maven>
-    </prerequisites>
     <modules>
         <module>jungrapht-visualization</module>
         <module>jungrapht-layout</module>

--- a/pom.xml
+++ b/pom.xml
@@ -54,22 +54,22 @@
     </distributionManagement>
     <properties>
         <cobertura.plugin.version>2.7</cobertura.plugin.version>
-        <compiler.plugin.version>3.11.0</compiler.plugin.version>
+        <compiler.plugin.version>3.12.1</compiler.plugin.version>
         <doclint>none</doclint>
         <fmt.plugin.version>1.8.0</fmt.plugin.version>
         <google-java-format.version>1.3</google-java-format.version>
         <gpg.plugin.version>1.6</gpg.plugin.version>
-        <jar.plugin.version>2.6</jar.plugin.version>
+        <jar.plugin.version>3.3.0</jar.plugin.version>
         <java.version>17</java.version>
-        <javadoc.plugin.version>3.1.0</javadoc.plugin.version>
-        <jgrapht.version>1.5.1</jgrapht.version>
+        <javadoc.plugin.version>3.6.3</javadoc.plugin.version>
+        <jgrapht.version>1.5.2</jgrapht.version>
         <junit.version>5.10.2</junit.version>
         <jxr.plugin.version>2.5</jxr.plugin.version>
         <pmd.plugin.version>3.12.0</pmd.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <release.plugin.version>2.5.3</release.plugin.version>
-        <source.plugin.version>3.0.1</source.plugin.version>
+        <source.plugin.version>3.3.0</source.plugin.version>
         <surefire.plugin.version>3.2.5</surefire.plugin.version>
         <version.logback>1.2.10</version.logback>
         <version.slf4j>1.7.32</version.slf4j>
@@ -126,7 +126,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${compiler.plugin.version}</version>
                     <configuration>
-                        <release>17</release>
+                        <release>${java.version}</release>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,10 @@
                     <artifactId>maven-site-plugin</artifactId>
                     <version>3.8.2</version>
                 </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${surefire.plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -200,10 +204,6 @@
                     <targetJdk>${java.version}</targetJdk>
                     <linkXref>true</linkXref>
                 </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.plugin.version}</version>
             </plugin>
         </plugins>
     </reporting>


### PR DESCRIPTION
This PR:
- Updates several dependencies, both for GHA and Maven
  - `actions/checkout@v3` and `actions/setup-java@v3` are both deprecated and are both updated to `v4`
- Makes the publish workflow _depend on_ the build workflow (i.e., if build fails, it won't try to publish)
- Disables the publish workflow being run in forked repositories (doesn't affect the original repository)
- Properly tells Maven to use the right version of the Surefire plugin (a follow-up for #26)
